### PR TITLE
Add Round Counter

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -8,7 +8,8 @@ There are two headers that show on all views. They reside at the top of the prog
 
 The first is the Input/Output (IO) bar. It provides controls for loading and saving creature lists and encounters. On the far right of this bar there is a button to open a new instance of the program in a new tab/window.
 
-The second is the encounter title. It simply displays the name of the currently loaded encounter. The name is also edited using the text field in this header.
+The second is the encounter title. It displays the name of the currently loaded encounter and the current round. The name and round are edited using the text field in this header.
+The round counter will automatically increase or decrease when the active turn wraps around the encounter list.
 
 While shown on all views, these headers can be minimized using controls in each view.
 
@@ -128,8 +129,8 @@ The card only displays information if a single creature is selected.
 
 There are 2 manipulable field on the encounter card:
 
-* **HP/MHP**: Current hit point of the creature and maximum hit point. 
-* **Notes**: This field should be used to keep track of any other variables of an individual creature (marker for the creature, status effects, used special abilities, etc.)
+* **HP/MHP**: Current hit point of the creature and maximum hit point.
+* **Notes**: This field should be used to keep track of any other variables of an individual creature (marker for the creature, status effects, used special abilities, etc.). This field also interacts with the round counter through a special 'round expression' syntax. Round expression are written as 'r{round_number}' (e.g. r{10} for round 10). When the specified round is reached the notes header will appear red, as an alert. Round expressions can also be entered in a relative format by putting a '+' in front of the round number (e.g. r{+5}). The relative format will automatically be converted to the correct number of round after the current one. 
 
 ## Saving and Loading
 Encounters and creature lists can be saved to json files and reloaded later.

--- a/Manual.md
+++ b/Manual.md
@@ -130,7 +130,7 @@ The card only displays information if a single creature is selected.
 There are 2 manipulable field on the encounter card:
 
 * **HP/MHP**: Current hit point of the creature and maximum hit point.
-* **Notes**: This field should be used to keep track of any other variables of an individual creature (marker for the creature, status effects, used special abilities, etc.). This field also interacts with the round counter through a special 'round expression' syntax. Round expression are written as 'r{round_number}' (e.g. r{10} for round 10). When the specified round is reached the notes header will appear red, as an alert. Round expressions can also be entered in a relative format by putting a '+' in front of the round number (e.g. r{+5}). The relative format will automatically be converted to the correct number of round after the current one. 
+* **Notes**: This field should be used to keep track of any other variables of an individual creature (marker for the creature, status effects, used special abilities, etc.). This field also interacts with the round counter through a special 'round expression' syntax. Round expressions are written as 'r{round_number}' (e.g. r{10} for round 10). When the specified round is reached the notes header will appear red, as an alert. Round expressions can also be entered in a relative format by putting a '+' in front of the round number (e.g. r{+5}). The relative format will automatically be converted to the correct number of rounds after the current one. 
 
 ## Saving and Loading
 Encounters and creature lists can be saved to json files and reloaded later.

--- a/src/css/RPG_init.css
+++ b/src/css/RPG_init.css
@@ -42,6 +42,8 @@ body {
 
 .encounter_title {
     font-size: 32pt;
+    display: inline-block;
+    margin: 0px;
 }
 
 .button_bar_button {

--- a/src/js_uncompiled/components.js
+++ b/src/js_uncompiled/components.js
@@ -105,15 +105,24 @@ class EncounterTitle extends React.Component{
     constructor(props){
         super(props);
         this.change_title = this.change_title.bind(this);
+        this.change_round = this.change_round.bind(this);
     }
 
     change_title(event){
         this.props.encounter.set_name(event.target.value);
     }
 
+    change_round(event){
+        this.props.encounter.set_round(parseInt(event.target.value));
+    }
+
     render(){
         return(
-            <input type="text" value={this.props.encounter.name} size="25" class="encounter_title" onChange={this.change_title}/>
+            <div>
+                <input type="text" value={this.props.encounter.name} size="25" class="encounter_title" onChange={this.change_title}/>
+                <p class="encounter_title">&nbsp; Round: </p>
+                <input type="text" value={this.props.encounter.round} size="1" class="encounter_title" onChange={this.change_round}/>
+            </div>
         )
     }
 }
@@ -297,6 +306,7 @@ class EncounterCard extends React.Component{
         super(props);
         this.get_creature = this.get_creature.bind(this);
         this.get_header = this.get_header.bind(this);
+        this.get_notes_color = this.get_notes_color.bind(this);
         this.set_hp = this.set_hp.bind(this);
         this.set_notes = this.set_notes.bind(this);
         this.abilities_style = this.abilities_style.bind(this);
@@ -334,6 +344,20 @@ class EncounterCard extends React.Component{
         else {
             return creature.name;
         }
+    }
+
+    get_notes_color(){
+        const encounter = this.props.encounter;
+        const notes = this.get_creature().notes;
+        const round_exps = notes.match(/r{\d+}/g);
+        if (round_exps){
+            for (const round_exp of round_exps){
+                if (round_exp.match(/\d+/g) == encounter.round.toString()){
+                    return "red";
+                }
+            }
+        }
+        return "grey";
     }
 
     set_hp(event){
@@ -393,7 +417,7 @@ class EncounterCard extends React.Component{
                 <p class="abilities">{this.get_creature().creature.atks}</p>
                 <table class="creature_table card_table">
                     <tr class="creature_table">
-                        <th class="creature_table">Notes</th>
+                        <th class="creature_table" style={{backgroundColor: this.get_notes_color()}}>Notes</th>
                     </tr>
                     <tr class="creature_table">
                         <td class="creature_table card_input"><textarea rows="5" cols="5" class="notes" value={this.get_creature().notes} onChange={this.set_notes}></textarea></td>

--- a/src/js_uncompiled/components.js
+++ b/src/js_uncompiled/components.js
@@ -113,7 +113,11 @@ class EncounterTitle extends React.Component{
     }
 
     change_round(event){
-        this.props.encounter.set_round(parseInt(event.target.value));
+        var value = parseInt(event.target.value);
+        if (isNaN(value)){
+            value = 0;
+        }
+        this.props.encounter.set_round(value);
     }
 
     render(){
@@ -121,7 +125,7 @@ class EncounterTitle extends React.Component{
             <div>
                 <input type="text" value={this.props.encounter.name} size="25" class="encounter_title" onChange={this.change_title}/>
                 <p class="encounter_title">&nbsp; Round: </p>
-                <input type="text" value={this.props.encounter.round} size="1" class="encounter_title" onChange={this.change_round}/>
+                <input type="text" value={this.props.encounter.round==0?"":this.props.encounter.round} size="1" class="encounter_title" onChange={this.change_round}/>
             </div>
         )
     }


### PR DESCRIPTION
Adds a round counter to the encounter title bar. This is an editable field that automatically updates when the active turn wraps around. The round is saved as part of the encounter json (this is backwards compatible with loading older encounter saves).

This also adds a special 'round expression' syntax. Round expressions are written as 'r{round_number}' (e.g. r{10} for round 10). When the specified round is reached the notes header will appear red, as an alert. Round expressions can also be entered in a relative format by putting a '+' in front of the round number (e.g. r{+5}). The relative format will automatically be converted to the correct number of rounds after the current one. 